### PR TITLE
fix: TXT api-hub consistency + v0.2 spec subsections documentation

### DIFF
--- a/docs/spec/agents-txt-v0.2.md
+++ b/docs/spec/agents-txt-v0.2.md
@@ -134,6 +134,13 @@ Every page in an agents.txt response must be annotated with a `type` field drawn
           "type": "string — one of the 12 content types",
           "method": "string — HTTP method, required for api-endpoint type (GET|POST|PATCH|DELETE)"
         }
+      ],
+      "subsections": [
+        {
+          "name": "string — subsection display name",
+          "page_count": "integer — number of pages in this subsection",
+          "pages": ["(same structure as sections[].pages)"]
+        }
       ]
     }
   ],
@@ -169,6 +176,10 @@ Every page in an agents.txt response must be annotated with a `type` field drawn
 | `pages[].title` | Yes | |
 | `pages[].type` | Yes | Must be one of the 12 types |
 | `pages[].method` | Conditional | Required when `type` is `api-endpoint` |
+| `sections[].subsections` | No | Use for sections with internal grouping (e.g., API Reference with Infrastructure, Messages, Admin sub-groups) |
+| `subsections[].name` | Yes* | Required when subsections is present |
+| `subsections[].page_count` | Yes* | Required when subsections is present |
+| `subsections[].pages` | Yes* | Required when subsections is present |
 | `sdk_pattern` | No | Use when 2+ SDKs share the same endpoint structure |
 | `navigation` | No | Use to provide intent-to-section shortcuts |
 
@@ -227,7 +238,11 @@ When a documentation site has multiple SDKs (e.g., Python, TypeScript, Java) eac
     "messages/create",
     "models",
     "models/list"
-  ]
+  ],
+  "endpoint_types": {
+    "hub_pages": ["messages", "messages/batches", "models"],
+    "endpoint_pages_type": "api-endpoint"
+  }
 }
 ```
 
@@ -237,6 +252,7 @@ When a documentation site has multiple SDKs (e.g., Python, TypeScript, Java) eac
 - `pages_per_sdk`: the number of pages each SDK exposes (must be consistent across all SDKs listed).
 - `url_template`: a URL template using `{sdk}` as a placeholder. Must match the actual URL structure.
 - `endpoint_paths`: the list of path suffixes that, combined with `url_template`, produce the full set of SDK pages. The length of this list must equal `pages_per_sdk`.
+- `endpoint_types` (optional): classifies which endpoint paths are hub/index pages (`hub_pages`, type `api-hub`) vs individual endpoints (type specified by `endpoint_pages_type`, default `api-endpoint`).
 
 ### When to Use
 
@@ -266,6 +282,21 @@ The optional `navigation` field provides intent-to-section shortcuts. It is a fl
 ```
 
 Navigation hints are advisory. Agents should use them to reduce search scope when the user's intent is clear, but must not treat them as authoritative routing rules.
+
+### Implementation Variations
+
+The `navigation` field supports flexible structures beyond flat key-value maps. Implementations may use nested objects for grouping:
+
+```json
+"navigation": {
+  "section_selection": {
+    "concept_or_feature": "/docs/en/build-with-claude/{feature}",
+    "api_endpoint": "/docs/en/api/{resource}/{action}"
+  }
+}
+```
+
+Parsers should handle both flat and nested navigation structures gracefully.
 
 ---
 

--- a/public/claude-code/agents.txt
+++ b/public/claude-code/agents.txt
@@ -171,37 +171,37 @@ SECTIONS: 9
 
   # Admin (34)
   admin | type=api-hub
-  admin/organizations | type=api-endpoint
+  admin/organizations | type=api-hub
   admin/organizations/me | type=api-endpoint
-  admin/users | type=api-endpoint
+  admin/users | type=api-hub
   admin/users/list | type=api-endpoint
   admin/users/retrieve | type=api-endpoint
   admin/users/update | type=api-endpoint
   admin/users/delete | type=api-endpoint
-  admin/invites | type=api-endpoint
+  admin/invites | type=api-hub
   admin/invites/create | type=api-endpoint
   admin/invites/retrieve | type=api-endpoint
   admin/invites/list | type=api-endpoint
   admin/invites/delete | type=api-endpoint
-  admin/api_keys | type=api-endpoint
+  admin/api_keys | type=api-hub
   admin/api_keys/list | type=api-endpoint
   admin/api_keys/retrieve | type=api-endpoint
   admin/api_keys/update | type=api-endpoint
-  admin/workspaces | type=api-endpoint
+  admin/workspaces | type=api-hub
   admin/workspaces/create | type=api-endpoint
   admin/workspaces/retrieve | type=api-endpoint
   admin/workspaces/list | type=api-endpoint
   admin/workspaces/update | type=api-endpoint
   admin/workspaces/archive | type=api-endpoint
-  admin/workspaces/members | type=api-endpoint
+  admin/workspaces/members | type=api-hub
   admin/workspaces/members/create | type=api-endpoint
   admin/workspaces/members/retrieve | type=api-endpoint
   admin/workspaces/members/list | type=api-endpoint
   admin/workspaces/members/update | type=api-endpoint
   admin/workspaces/members/delete | type=api-endpoint
-  admin/cost_report | type=api-endpoint
+  admin/cost_report | type=api-hub
   admin/cost_report/retrieve | type=api-endpoint
-  admin/usage_report | type=api-endpoint
+  admin/usage_report | type=api-hub
   admin/usage_report/retrieve_messages | type=api-endpoint
   admin/usage_report/retrieve_claude_code | type=api-endpoint
 

--- a/scripts/generate_formats.py
+++ b/scripts/generate_formats.py
@@ -1105,19 +1105,6 @@ _CC_INTRO_DESCRIPTIONS: dict[str, str] = {
     "/docs/en/get-started": "Quick start tutorial",
 }
 
-# TXT admin section: sub-resource hub pages become api-endpoint
-# (only the root 'admin' page keeps api-hub)
-_TXT_ADMIN_FORCE_ENDPOINT_PATHS = {
-    "/docs/en/api/admin/organizations",
-    "/docs/en/api/admin/users",
-    "/docs/en/api/admin/invites",
-    "/docs/en/api/admin/api_keys",
-    "/docs/en/api/admin/workspaces",
-    "/docs/en/api/admin/workspaces/members",
-    "/docs/en/api/admin/cost_report",
-    "/docs/en/api/admin/usage_report",
-}
-
 
 def _txt_build_claude_intro() -> list[str]:
     """Render Introduction section for claude-code TXT."""
@@ -1159,10 +1146,7 @@ def _txt_build_api_ref(section: dict, sdk_pattern: dict | None) -> list[str]:
             else:
                 rel = path
 
-            # Determine type, applying admin override
             page_type = page.get("type", "")
-            if path in _TXT_ADMIN_FORCE_ENDPOINT_PATHS:
-                page_type = "api-endpoint"
 
             lines.append(f"  {rel} | type={page_type}")
 


### PR DESCRIPTION
## Summary

- **TXT api-hub 타입 일관성**: generate_formats.py에서 admin hub 페이지를 api-endpoint로 강제 변환하던 오버라이드 제거. 이제 JSON과 TXT 간 8건의 타입 불일치 해소.
- **v0.2 스펙 보완**: subsections 필드, endpoint_types 필드, navigation 구조 변형을 스펙에 문서화

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Generator | `scripts/generate_formats.py` | Remove admin api-hub override |
| Formats | `public/*/agents.txt` | Regenerated with correct api-hub types |
| Spec | `docs/spec/agents-txt-v0.2.md` | Add subsections, endpoint_types, navigation docs |

## Test plan

- [ ] TXT의 admin hub 페이지 8건이 `type=api-hub`으로 표시 확인
- [ ] JSON vs TXT 간 api-hub/api-endpoint 불일치 0건 확인
- [ ] v0.2 스펙에 subsections, endpoint_types 필드 문서화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)