### PR TITLE
fix: resolve documentation drift #21 and #22

### DIFF
--- a/public/agents.json
+++ b/public/agents.json
@@ -1,0 +1,59 @@
+{
+  "agents_txt_version": "0.2",
+  "site": {
+    "name": "AgentNav",
+    "url": "https://agentnav.baekenough.com",
+    "description": "AI Agent Documentation Navigator — agents.txt standard implementation providing structured documentation for AI coding assistants",
+    "total_documentation_sets": 3,
+    "last_updated": "2026-03-22"
+  },
+  "documentation_sets": [
+    {
+      "name": "Anthropic Claude API",
+      "path": "/claude-code/",
+      "source_url": "https://platform.claude.com/docs",
+      "total_pages": 651,
+      "sections": 9,
+      "formats": {
+        "json": "/claude-code/agents.json",
+        "markdown": "/claude-code/agents.md",
+        "xml": "/claude-code/agents.xml",
+        "text": "/claude-code/agents.txt"
+      }
+    },
+    {
+      "name": "GPT Codex",
+      "path": "/gpt-codex/",
+      "source_url": "https://developers.openai.com",
+      "total_pages": 69,
+      "sections": 14,
+      "formats": {
+        "json": "/gpt-codex/agents.json",
+        "markdown": "/gpt-codex/agents.md",
+        "xml": "/gpt-codex/agents.xml",
+        "text": "/gpt-codex/agents.txt"
+      }
+    },
+    {
+      "name": "Gemini CLI",
+      "path": "/gemini-cli/",
+      "source_url": "https://geminicli.com",
+      "total_pages": 69,
+      "sections": 9,
+      "formats": {
+        "json": "/gemini-cli/agents.json",
+        "markdown": "/gemini-cli/agents.md",
+        "xml": "/gemini-cli/agents.xml",
+        "text": "/gemini-cli/agents.txt"
+      }
+    }
+  ],
+  "navigation": {
+    "tips": [
+      "Each documentation set has 4 formats: JSON, Markdown, XML, and Plain Text",
+      "Use JSON for structured parsing, Markdown for LLM consumption, TXT for minimal tokens",
+      "Access individual sets via /{set-name}/agents.{format}",
+      "Query parameter shortcut: /?docs={set-name} redirects to the set's index page"
+    ]
+  }
+}

--- a/public/agents.md
+++ b/public/agents.md
@@ -1,0 +1,49 @@
+---
+agents_txt_version: "0.2"
+format: markdown
+type: site-index
+---
+
+# AgentNav — Documentation Sets
+
+- **URL**: https://agentnav.baekenough.com
+- **Standard**: agents.txt v0.2
+- **Documentation Sets**: 3
+- **Total Pages**: 789
+- **Last Updated**: 2026-03-22
+
+## Available Documentation Sets
+
+### Anthropic Claude API
+- **Source**: [platform.claude.com/docs](https://platform.claude.com/docs)
+- **Pages**: 651 | **Sections**: 9
+- **Formats**:
+  - [agents.json](/claude-code/agents.json)
+  - [agents.md](/claude-code/agents.md)
+  - [agents.xml](/claude-code/agents.xml)
+  - [agents.txt](/claude-code/agents.txt)
+
+### GPT Codex
+- **Source**: [developers.openai.com](https://developers.openai.com)
+- **Pages**: 69 | **Sections**: 14
+- **Formats**:
+  - [agents.json](/gpt-codex/agents.json)
+  - [agents.md](/gpt-codex/agents.md)
+  - [agents.xml](/gpt-codex/agents.xml)
+  - [agents.txt](/gpt-codex/agents.txt)
+
+### Gemini CLI
+- **Source**: [geminicli.com](https://geminicli.com)
+- **Pages**: 69 | **Sections**: 9
+- **Formats**:
+  - [agents.json](/gemini-cli/agents.json)
+  - [agents.md](/gemini-cli/agents.md)
+  - [agents.xml](/gemini-cli/agents.xml)
+  - [agents.txt](/gemini-cli/agents.txt)
+
+## Navigation Guide
+
+1. Each documentation set provides structured page inventories in 4 formats
+2. Use JSON for structured parsing, Markdown for LLM consumption, TXT for minimal tokens
+3. Access via `/{set-name}/agents.{format}` (e.g., `/claude-code/agents.json`)
+4. Query parameter shortcut: `/?docs={set-name}` redirects to the set's index

--- a/public/agents.txt
+++ b/public/agents.txt
@@ -1,0 +1,36 @@
+# agents.txt v0.2
+# AgentNav — https://agentnav.baekenough.com
+# Documentation Sets: 3 | Total Pages: 789 | Last updated: 2026-03-22
+
+SITE: AgentNav
+URL: https://agentnav.baekenough.com
+TYPE: site-index
+SETS: 3
+PAGES: 789
+
+== DOCUMENTATION SETS ==
+
+[Anthropic Claude API] 651 pages, 9 sections | source=https://platform.claude.com/docs
+  json: /claude-code/agents.json
+  md: /claude-code/agents.md
+  xml: /claude-code/agents.xml
+  txt: /claude-code/agents.txt
+
+[GPT Codex] 69 pages, 14 sections | source=https://developers.openai.com
+  json: /gpt-codex/agents.json
+  md: /gpt-codex/agents.md
+  xml: /gpt-codex/agents.xml
+  txt: /gpt-codex/agents.txt
+
+[Gemini CLI] 69 pages, 9 sections | source=https://geminicli.com
+  json: /gemini-cli/agents.json
+  md: /gemini-cli/agents.md
+  xml: /gemini-cli/agents.xml
+  txt: /gemini-cli/agents.txt
+
+== NAVIGATION ==
+RULES:
+1. Each set has 4 formats — choose based on your parsing needs
+2. JSON for structured parsing, Markdown for LLM context, TXT for minimal tokens
+3. Access: /{set-name}/agents.{format}
+4. Shortcut: /?docs={set-name} redirects to set index page

--- a/public/claude-code/agents.json
+++ b/public/claude-code/agents.json
@@ -1,10 +1,10 @@
 {
   "agents_txt_version": "0.2",
   "site": {
-    "name": "Claude Documentation",
+    "name": "Anthropic Claude API Documentation",
     "url": "https://platform.claude.com/docs",
     "total_pages": 651,
-    "last_updated": "2026-03-07"
+    "last_updated": "2026-03-22"
   },
   "sections": [
     {

--- a/public/claude-code/agents.md
+++ b/public/claude-code/agents.md
@@ -10,12 +10,12 @@ schema:
   navigation: "See ## Navigation Guide section"
 ---
 
-# Claude Documentation
+# Anthropic Claude API Documentation
 
 - **URL**: https://platform.claude.com/docs
 - **Standard**: agents.txt v0.2 (AgentNav PoC)
 - **Total Pages**: 651
-- **Last Updated**: 2026-03-07
+- **Last Updated**: 2026-03-22
 
 ## Site Overview
 

--- a/public/claude-code/agents.txt
+++ b/public/claude-code/agents.txt
@@ -1,8 +1,8 @@
 # agents.txt v0.2
-# Claude Documentation — https://platform.claude.com/docs
-# Total: 651 pages | Last updated: 2026-03-07
+# Anthropic Claude API Documentation — https://platform.claude.com/docs
+# Total: 651 pages | Last updated: 2026-03-22
 
-SITE: Claude Documentation
+SITE: Anthropic Claude API Documentation
 URL: https://platform.claude.com/docs
 PAGES: 651
 SECTIONS: 9

--- a/public/claude-code/agents.xml
+++ b/public/claude-code/agents.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <agents version="0.2">
-  <site name="Claude Documentation" url="https://platform.claude.com/docs" total-pages="651" last-updated="2026-03-07" />
+  <site name="Anthropic Claude API Documentation" url="https://platform.claude.com/docs" total-pages="651" last-updated="2026-03-22" />
 
   <sections>
     <!-- 1. Introduction -->

--- a/public/gemini-cli/agents.json
+++ b/public/gemini-cli/agents.json
@@ -1,0 +1,155 @@
+{
+  "agents_txt_version": "0.2",
+  "site": {
+    "name": "Gemini CLI Documentation",
+    "url": "https://geminicli.com",
+    "total_pages": 69,
+    "last_updated": "2026-03-22"
+  },
+  "sections": [
+    {
+      "name": "Get Started",
+      "path_prefix": "/docs",
+      "page_count": 7,
+      "pages": [
+        { "path": "/docs/", "title": "Overview", "type": "overview" },
+        { "path": "/docs/get-started/", "title": "Quickstart", "type": "tutorial" },
+        { "path": "/docs/get-started/installation/", "title": "Installation", "type": "tutorial" },
+        { "path": "/docs/get-started/authentication/", "title": "Authentication", "type": "tutorial" },
+        { "path": "/docs/get-started/examples/", "title": "Examples", "type": "tutorial" },
+        { "path": "/docs/cli/cli-reference/", "title": "CLI Cheatsheet", "type": "reference" },
+        { "path": "/docs/get-started/gemini-3/", "title": "Gemini 3 on Gemini CLI", "type": "overview" }
+      ]
+    },
+    {
+      "name": "Tutorials",
+      "path_prefix": "/docs/cli/tutorials",
+      "page_count": 10,
+      "pages": [
+        { "path": "/docs/cli/tutorials/file-management/", "title": "File Management", "type": "tutorial" },
+        { "path": "/docs/cli/tutorials/skills-getting-started/", "title": "Get Started with Agent Skills", "type": "tutorial" },
+        { "path": "/docs/cli/tutorials/memory-management/", "title": "Manage Context and Memory", "type": "tutorial" },
+        { "path": "/docs/cli/tutorials/shell-commands/", "title": "Execute Shell Commands", "type": "tutorial" },
+        { "path": "/docs/cli/tutorials/session-management/", "title": "Manage Sessions and History", "type": "tutorial" },
+        { "path": "/docs/cli/tutorials/task-planning/", "title": "Plan Tasks with Todos", "type": "tutorial" },
+        { "path": "/docs/cli/tutorials/plan-mode-steering/", "title": "Use Plan Mode with Model Steering", "type": "tutorial" },
+        { "path": "/docs/cli/tutorials/web-tools/", "title": "Web Search and Fetch", "type": "tutorial" },
+        { "path": "/docs/cli/tutorials/mcp-setup/", "title": "Set Up an MCP Server", "type": "tutorial" },
+        { "path": "/docs/cli/tutorials/automation/", "title": "Automate Tasks", "type": "tutorial" }
+      ]
+    },
+    {
+      "name": "Extensions",
+      "path_prefix": "/docs/extensions",
+      "page_count": 5,
+      "pages": [
+        { "path": "/docs/extensions/", "title": "Extensions Overview", "type": "overview" },
+        { "path": "/docs/extensions/writing-extensions/", "title": "Developer Guide: Build Extensions", "type": "guide" },
+        { "path": "/docs/extensions/best-practices/", "title": "Developer Guide: Best Practices", "type": "best-practices" },
+        { "path": "/docs/extensions/releasing/", "title": "Developer Guide: Releasing", "type": "guide" },
+        { "path": "/docs/extensions/reference/", "title": "Developer Guide: Reference", "type": "reference" }
+      ]
+    },
+    {
+      "name": "Features",
+      "path_prefix": "/docs",
+      "page_count": 20,
+      "pages": [
+        { "path": "/docs/cli/skills/", "title": "Agent Skills", "type": "guide" },
+        { "path": "/docs/cli/checkpointing/", "title": "Checkpointing", "type": "guide" },
+        { "path": "/docs/cli/headless/", "title": "Headless Mode", "type": "guide" },
+        { "path": "/docs/cli/git-worktrees/", "title": "Git Worktrees", "type": "guide" },
+        { "path": "/docs/hooks/", "title": "Hooks Overview", "type": "guide" },
+        { "path": "/docs/hooks/reference/", "title": "Hooks Reference", "type": "reference" },
+        { "path": "/docs/ide-integration/", "title": "IDE Integration", "type": "guide" },
+        { "path": "/docs/tools/mcp-server/", "title": "MCP Servers", "type": "guide" },
+        { "path": "/docs/cli/model-routing/", "title": "Model Routing", "type": "guide" },
+        { "path": "/docs/cli/model/", "title": "Model Selection", "type": "guide" },
+        { "path": "/docs/cli/model-steering/", "title": "Model Steering", "type": "guide" },
+        { "path": "/docs/cli/notifications/", "title": "Notifications", "type": "guide" },
+        { "path": "/docs/cli/plan-mode/", "title": "Plan Mode", "type": "guide" },
+        { "path": "/docs/core/subagents/", "title": "Subagents", "type": "guide" },
+        { "path": "/docs/core/remote-agents/", "title": "Remote Subagents", "type": "guide" },
+        { "path": "/docs/cli/rewind/", "title": "Rewind", "type": "guide" },
+        { "path": "/docs/cli/sandbox/", "title": "Sandboxing", "type": "guide" },
+        { "path": "/docs/cli/settings/", "title": "Settings", "type": "reference" },
+        { "path": "/docs/cli/telemetry/", "title": "Telemetry", "type": "reference" },
+        { "path": "/docs/cli/token-caching/", "title": "Token Caching", "type": "guide" }
+      ]
+    },
+    {
+      "name": "Configuration",
+      "path_prefix": "/docs/cli",
+      "page_count": 8,
+      "pages": [
+        { "path": "/docs/cli/custom-commands/", "title": "Custom Commands", "type": "guide" },
+        { "path": "/docs/cli/enterprise/", "title": "Enterprise Configuration", "type": "guide" },
+        { "path": "/docs/cli/gemini-ignore/", "title": "Ignore Files (.geminiignore)", "type": "reference" },
+        { "path": "/docs/cli/generation-settings/", "title": "Model Configuration", "type": "reference" },
+        { "path": "/docs/cli/gemini-md/", "title": "Project Context (GEMINI.md)", "type": "guide" },
+        { "path": "/docs/cli/system-prompt/", "title": "System Prompt Override", "type": "guide" },
+        { "path": "/docs/cli/themes/", "title": "Themes", "type": "guide" },
+        { "path": "/docs/cli/trusted-folders/", "title": "Trusted Folders", "type": "guide" }
+      ]
+    },
+    {
+      "name": "Reference",
+      "path_prefix": "/docs/reference",
+      "page_count": 6,
+      "pages": [
+        { "path": "/docs/reference/commands/", "title": "Command Reference", "type": "reference" },
+        { "path": "/docs/reference/configuration/", "title": "Configuration Reference", "type": "reference" },
+        { "path": "/docs/reference/keyboard-shortcuts/", "title": "Keyboard Shortcuts", "type": "reference" },
+        { "path": "/docs/reference/memport/", "title": "Memory Import Processor", "type": "tool-reference" },
+        { "path": "/docs/reference/policy-engine/", "title": "Policy Engine", "type": "reference" },
+        { "path": "/docs/reference/tools/", "title": "Tools Reference", "type": "tool-reference" }
+      ]
+    },
+    {
+      "name": "Resources",
+      "path_prefix": "/docs/resources",
+      "page_count": 5,
+      "pages": [
+        { "path": "/docs/resources/faq/", "title": "FAQ", "type": "reference" },
+        { "path": "/docs/resources/quota-and-pricing/", "title": "Quota and Pricing", "type": "reference" },
+        { "path": "/docs/resources/tos-privacy/", "title": "Terms and Privacy", "type": "reference" },
+        { "path": "/docs/resources/troubleshooting/", "title": "Troubleshooting", "type": "guide" },
+        { "path": "/docs/resources/uninstall/", "title": "Uninstall", "type": "guide" }
+      ]
+    },
+    {
+      "name": "Development",
+      "path_prefix": "/docs",
+      "page_count": 5,
+      "pages": [
+        { "path": "/docs/contributing/", "title": "Contribution Guide", "type": "guide" },
+        { "path": "/docs/integration-tests/", "title": "Integration Testing", "type": "guide" },
+        { "path": "/docs/issue-and-pr-automation/", "title": "Issue and PR Automation", "type": "guide" },
+        { "path": "/docs/local-development/", "title": "Local Development", "type": "guide" },
+        { "path": "/docs/npm/", "title": "NPM Package Structure", "type": "reference" }
+      ]
+    },
+    {
+      "name": "Releases",
+      "path_prefix": "/docs/changelogs",
+      "page_count": 3,
+      "pages": [
+        { "path": "/docs/changelogs/", "title": "Release Notes", "type": "changelog" },
+        { "path": "/docs/changelogs/latest/", "title": "Stable Release", "type": "changelog" },
+        { "path": "/docs/changelogs/preview/", "title": "Preview Release", "type": "changelog" }
+      ]
+    }
+  ],
+  "navigation": {
+    "default_section": "Get Started",
+    "search_priority": ["Get Started", "Tutorials", "Features", "Configuration", "Reference", "Extensions"],
+    "tips": [
+      "Start with /docs/get-started/ for initial setup",
+      "Use /docs/cli/tutorials/ for step-by-step guides on common tasks",
+      "Extensions at /docs/extensions/ for building plugins",
+      "Configuration covers GEMINI.md, model settings, themes, and enterprise setup",
+      "For complete tool and command reference, see the Reference section",
+      "Subagents and model routing are key features for advanced workflows"
+    ]
+  }
+}

--- a/public/gemini-cli/agents.md
+++ b/public/gemini-cli/agents.md
@@ -1,0 +1,158 @@
+---
+agents_txt_version: "0.2"
+format: markdown
+schema:
+  sections: "## heading = section name"
+  subsections: "### heading = subsection grouping"
+  pages: "- [title](path) {type}"
+  page_types: [overview, tutorial, guide, reference, tool-reference, best-practices, changelog]
+  navigation: "See ## Navigation Guide section"
+---
+
+# Gemini CLI Documentation
+
+- **URL**: https://geminicli.com
+- **Standard**: agents.txt v0.2 (AgentNav PoC)
+- **Total Pages**: 69
+- **Last Updated**: 2026-03-22
+
+## Site Overview
+
+| # | Section | Pages | Base Path |
+|---|---------|-------|-----------|
+| 1 | Get Started | 7 | /docs/ |
+| 2 | Tutorials | 10 | /docs/cli/tutorials/ |
+| 3 | Extensions | 5 | /docs/extensions/ |
+| 4 | Features | 20 | /docs/ |
+| 5 | Configuration | 8 | /docs/cli/ |
+| 6 | Reference | 6 | /docs/reference/ |
+| 7 | Resources | 5 | /docs/resources/ |
+| 8 | Development | 5 | /docs/ |
+| 9 | Releases | 3 | /docs/changelogs/ |
+
+---
+
+## Get Started (7 pages)
+
+- [Overview](/docs/) {overview}
+- [Quickstart](/docs/get-started/) {tutorial}
+- [Installation](/docs/get-started/installation/) {tutorial}
+- [Authentication](/docs/get-started/authentication/) {tutorial}
+- [Examples](/docs/get-started/examples/) {tutorial}
+- [CLI Cheatsheet](/docs/cli/cli-reference/) {reference}
+- [Gemini 3 on Gemini CLI](/docs/get-started/gemini-3/) {overview}
+
+## Tutorials (10 pages)
+
+- [File Management](/docs/cli/tutorials/file-management/) {tutorial}
+- [Get Started with Agent Skills](/docs/cli/tutorials/skills-getting-started/) {tutorial}
+- [Manage Context and Memory](/docs/cli/tutorials/memory-management/) {tutorial}
+- [Execute Shell Commands](/docs/cli/tutorials/shell-commands/) {tutorial}
+- [Manage Sessions and History](/docs/cli/tutorials/session-management/) {tutorial}
+- [Plan Tasks with Todos](/docs/cli/tutorials/task-planning/) {tutorial}
+- [Use Plan Mode with Model Steering](/docs/cli/tutorials/plan-mode-steering/) {tutorial}
+- [Web Search and Fetch](/docs/cli/tutorials/web-tools/) {tutorial}
+- [Set Up an MCP Server](/docs/cli/tutorials/mcp-setup/) {tutorial}
+- [Automate Tasks](/docs/cli/tutorials/automation/) {tutorial}
+
+## Extensions (5 pages)
+
+- [Extensions Overview](/docs/extensions/) {overview}
+- [Developer Guide: Build Extensions](/docs/extensions/writing-extensions/) {guide}
+- [Developer Guide: Best Practices](/docs/extensions/best-practices/) {best-practices}
+- [Developer Guide: Releasing](/docs/extensions/releasing/) {guide}
+- [Developer Guide: Reference](/docs/extensions/reference/) {reference}
+
+## Features (20 pages)
+
+- [Agent Skills](/docs/cli/skills/) {guide}
+- [Checkpointing](/docs/cli/checkpointing/) {guide}
+- [Headless Mode](/docs/cli/headless/) {guide}
+- [Git Worktrees](/docs/cli/git-worktrees/) {guide}
+- [Hooks Overview](/docs/hooks/) {guide}
+- [Hooks Reference](/docs/hooks/reference/) {reference}
+- [IDE Integration](/docs/ide-integration/) {guide}
+- [MCP Servers](/docs/tools/mcp-server/) {guide}
+- [Model Routing](/docs/cli/model-routing/) {guide}
+- [Model Selection](/docs/cli/model/) {guide}
+- [Model Steering](/docs/cli/model-steering/) {guide}
+- [Notifications](/docs/cli/notifications/) {guide}
+- [Plan Mode](/docs/cli/plan-mode/) {guide}
+- [Subagents](/docs/core/subagents/) {guide}
+- [Remote Subagents](/docs/core/remote-agents/) {guide}
+- [Rewind](/docs/cli/rewind/) {guide}
+- [Sandboxing](/docs/cli/sandbox/) {guide}
+- [Settings](/docs/cli/settings/) {reference}
+- [Telemetry](/docs/cli/telemetry/) {reference}
+- [Token Caching](/docs/cli/token-caching/) {guide}
+
+## Configuration (8 pages)
+
+- [Custom Commands](/docs/cli/custom-commands/) {guide}
+- [Enterprise Configuration](/docs/cli/enterprise/) {guide}
+- [Ignore Files (.geminiignore)](/docs/cli/gemini-ignore/) {reference}
+- [Model Configuration](/docs/cli/generation-settings/) {reference}
+- [Project Context (GEMINI.md)](/docs/cli/gemini-md/) {guide}
+- [System Prompt Override](/docs/cli/system-prompt/) {guide}
+- [Themes](/docs/cli/themes/) {guide}
+- [Trusted Folders](/docs/cli/trusted-folders/) {guide}
+
+## Reference (6 pages)
+
+- [Command Reference](/docs/reference/commands/) {reference}
+- [Configuration Reference](/docs/reference/configuration/) {reference}
+- [Keyboard Shortcuts](/docs/reference/keyboard-shortcuts/) {reference}
+- [Memory Import Processor](/docs/reference/memport/) {tool-reference}
+- [Policy Engine](/docs/reference/policy-engine/) {reference}
+- [Tools Reference](/docs/reference/tools/) {tool-reference}
+
+## Resources (5 pages)
+
+- [FAQ](/docs/resources/faq/) {reference}
+- [Quota and Pricing](/docs/resources/quota-and-pricing/) {reference}
+- [Terms and Privacy](/docs/resources/tos-privacy/) {reference}
+- [Troubleshooting](/docs/resources/troubleshooting/) {guide}
+- [Uninstall](/docs/resources/uninstall/) {guide}
+
+## Development (5 pages)
+
+- [Contribution Guide](/docs/contributing/) {guide}
+- [Integration Testing](/docs/integration-tests/) {guide}
+- [Issue and PR Automation](/docs/issue-and-pr-automation/) {guide}
+- [Local Development](/docs/local-development/) {guide}
+- [NPM Package Structure](/docs/npm/) {reference}
+
+## Releases (3 pages)
+
+- [Release Notes](/docs/changelogs/) {changelog}
+- [Stable Release](/docs/changelogs/latest/) {changelog}
+- [Preview Release](/docs/changelogs/preview/) {changelog}
+
+---
+
+## Navigation Guide
+
+### Quick Navigation
+
+| Intent | Best Section | Key Pages |
+|--------|-------------|-----------|
+| Getting started | Get Started | Overview, Quickstart, Installation |
+| Step-by-step guides | Tutorials | File Management, Shell Commands, MCP Setup |
+| Build plugins | Extensions | Extensions Overview, Build Extensions, Best Practices |
+| Core features | Features | Agent Skills, Hooks, Subagents, MCP Servers |
+| IDE integration | Features | IDE Integration |
+| Model options | Features | Model Selection, Model Routing, Model Steering |
+| Project setup | Configuration | Project Context (GEMINI.md), Enterprise Configuration |
+| Commands and tools | Reference | Command Reference, Tools Reference |
+| Troubleshooting | Resources | Troubleshooting, FAQ |
+| Contributing | Development | Contribution Guide, Local Development |
+| Release history | Releases | Release Notes, Stable Release |
+
+### Search Priority
+
+1. Get Started — overview, quickstart, installation
+2. Tutorials — step-by-step guides for common tasks
+3. Features — agent skills, hooks, model routing, subagents
+4. Configuration — GEMINI.md, enterprise, themes, ignore files
+5. Reference — commands, tools, keyboard shortcuts
+6. Extensions — build and publish plugins

--- a/public/gemini-cli/agents.txt
+++ b/public/gemini-cli/agents.txt
@@ -1,0 +1,131 @@
+# agents.txt v0.2
+# Gemini CLI Documentation — https://geminicli.com
+# Total: 69 pages | Last updated: 2026-03-22
+
+SITE: Gemini CLI Documentation
+URL: https://geminicli.com
+PAGES: 69
+SECTIONS: 9
+
+== SCHEMA ==
+# Formal grammar for parsing this file
+# HEADER: key-value pairs (KEY: value)
+# SECTION: [Name] N pages | prefix=/path/
+# PAGE: relative-path | type=TYPE
+# PAGE (absolute): /full/path | type=TYPE
+# NAVIGATION: RULES (numbered), INTENT MAP (intent → section)
+# TYPES: overview, tutorial, guide, reference, use-case, tool-reference, sdk-guide, changelog
+# DELIMITER: | separates path from type
+# PREFIX RULE: full_url = URL + path
+
+== SECTIONS ==
+
+[Get Started] 7 pages | prefix=/docs/
+   | type=overview
+  get-started/ | type=tutorial
+  get-started/installation/ | type=tutorial
+  get-started/authentication/ | type=tutorial
+  get-started/examples/ | type=tutorial
+  cli/cli-reference/ | type=reference
+  get-started/gemini-3/ | type=overview
+
+[Tutorials] 10 pages | prefix=/docs/cli/tutorials/
+  file-management/ | type=tutorial
+  skills-getting-started/ | type=tutorial
+  memory-management/ | type=tutorial
+  shell-commands/ | type=tutorial
+  session-management/ | type=tutorial
+  task-planning/ | type=tutorial
+  plan-mode-steering/ | type=tutorial
+  web-tools/ | type=tutorial
+  mcp-setup/ | type=tutorial
+  automation/ | type=tutorial
+
+[Extensions] 5 pages | prefix=/docs/extensions/
+   | type=overview
+  writing-extensions/ | type=guide
+  best-practices/ | type=best-practices
+  releasing/ | type=guide
+  reference/ | type=reference
+
+[Features] 20 pages | prefix=/docs/
+  cli/skills/ | type=guide
+  cli/checkpointing/ | type=guide
+  cli/headless/ | type=guide
+  cli/git-worktrees/ | type=guide
+  hooks/ | type=guide
+  hooks/reference/ | type=reference
+  ide-integration/ | type=guide
+  tools/mcp-server/ | type=guide
+  cli/model-routing/ | type=guide
+  cli/model/ | type=guide
+  cli/model-steering/ | type=guide
+  cli/notifications/ | type=guide
+  cli/plan-mode/ | type=guide
+  core/subagents/ | type=guide
+  core/remote-agents/ | type=guide
+  cli/rewind/ | type=guide
+  cli/sandbox/ | type=guide
+  cli/settings/ | type=reference
+  cli/telemetry/ | type=reference
+  cli/token-caching/ | type=guide
+
+[Configuration] 8 pages | prefix=/docs/cli/
+  custom-commands/ | type=guide
+  enterprise/ | type=guide
+  gemini-ignore/ | type=reference
+  generation-settings/ | type=reference
+  gemini-md/ | type=guide
+  system-prompt/ | type=guide
+  themes/ | type=guide
+  trusted-folders/ | type=guide
+
+[Reference] 6 pages | prefix=/docs/reference/
+  commands/ | type=reference
+  configuration/ | type=reference
+  keyboard-shortcuts/ | type=reference
+  memport/ | type=tool-reference
+  policy-engine/ | type=reference
+  tools/ | type=tool-reference
+
+[Resources] 5 pages | prefix=/docs/resources/
+  faq/ | type=reference
+  quota-and-pricing/ | type=reference
+  tos-privacy/ | type=reference
+  troubleshooting/ | type=guide
+  uninstall/ | type=guide
+
+[Development] 5 pages | prefix=/docs/
+  contributing/ | type=guide
+  integration-tests/ | type=guide
+  issue-and-pr-automation/ | type=guide
+  local-development/ | type=guide
+  npm/ | type=reference
+
+[Releases] 3 pages | prefix=/docs/changelogs/
+   | type=changelog
+  latest/ | type=changelog
+  preview/ | type=changelog
+
+== NAVIGATION ==
+
+RULES:
+  1. Start with "Get Started" for installation and quickstart
+  2. Use "Tutorials" for step-by-step guides on common tasks
+  3. "Features" covers agent skills, hooks, model routing, and subagents
+  4. Configuration covers GEMINI.md, enterprise setup, themes, and ignore files
+  5. "Reference" has complete command, tool, and keyboard shortcut docs
+  6. "Extensions" for building and publishing plugins
+
+INTENT MAP:
+  getting started     → Get Started
+  step-by-step guide  → Tutorials
+  build plugins       → Extensions
+  core features       → Features
+  ide integration     → Features
+  model options       → Features
+  project setup       → Configuration
+  commands / tools    → Reference
+  troubleshooting     → Resources
+  contributing        → Development
+  release history     → Releases

--- a/public/gemini-cli/agents.xml
+++ b/public/gemini-cli/agents.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<agents version="0.2">
+  <site name="Gemini CLI Documentation" url="https://geminicli.com" total-pages="69" last-updated="2026-03-22" />
+
+  <sections>
+    <!-- 1. Get Started -->
+    <section name="Get Started" path-prefix="/docs" page-count="7">
+      <page path="/docs/" title="Overview" type="overview" />
+      <page path="/docs/get-started/" title="Quickstart" type="tutorial" />
+      <page path="/docs/get-started/installation/" title="Installation" type="tutorial" />
+      <page path="/docs/get-started/authentication/" title="Authentication" type="tutorial" />
+      <page path="/docs/get-started/examples/" title="Examples" type="tutorial" />
+      <page path="/docs/cli/cli-reference/" title="CLI Cheatsheet" type="reference" />
+      <page path="/docs/get-started/gemini-3/" title="Gemini 3 on Gemini CLI" type="overview" />
+    </section>
+
+    <!-- 2. Tutorials -->
+    <section name="Tutorials" path-prefix="/docs/cli/tutorials" page-count="10">
+      <page path="/docs/cli/tutorials/file-management/" title="File Management" type="tutorial" />
+      <page path="/docs/cli/tutorials/skills-getting-started/" title="Get Started with Agent Skills" type="tutorial" />
+      <page path="/docs/cli/tutorials/memory-management/" title="Manage Context and Memory" type="tutorial" />
+      <page path="/docs/cli/tutorials/shell-commands/" title="Execute Shell Commands" type="tutorial" />
+      <page path="/docs/cli/tutorials/session-management/" title="Manage Sessions and History" type="tutorial" />
+      <page path="/docs/cli/tutorials/task-planning/" title="Plan Tasks with Todos" type="tutorial" />
+      <page path="/docs/cli/tutorials/plan-mode-steering/" title="Use Plan Mode with Model Steering" type="tutorial" />
+      <page path="/docs/cli/tutorials/web-tools/" title="Web Search and Fetch" type="tutorial" />
+      <page path="/docs/cli/tutorials/mcp-setup/" title="Set Up an MCP Server" type="tutorial" />
+      <page path="/docs/cli/tutorials/automation/" title="Automate Tasks" type="tutorial" />
+    </section>
+
+    <!-- 3. Extensions -->
+    <section name="Extensions" path-prefix="/docs/extensions" page-count="5">
+      <page path="/docs/extensions/" title="Extensions Overview" type="overview" />
+      <page path="/docs/extensions/writing-extensions/" title="Developer Guide: Build Extensions" type="guide" />
+      <page path="/docs/extensions/best-practices/" title="Developer Guide: Best Practices" type="best-practices" />
+      <page path="/docs/extensions/releasing/" title="Developer Guide: Releasing" type="guide" />
+      <page path="/docs/extensions/reference/" title="Developer Guide: Reference" type="reference" />
+    </section>
+
+    <!-- 4. Features -->
+    <section name="Features" path-prefix="/docs" page-count="20">
+      <page path="/docs/cli/skills/" title="Agent Skills" type="guide" />
+      <page path="/docs/cli/checkpointing/" title="Checkpointing" type="guide" />
+      <page path="/docs/cli/headless/" title="Headless Mode" type="guide" />
+      <page path="/docs/cli/git-worktrees/" title="Git Worktrees" type="guide" />
+      <page path="/docs/hooks/" title="Hooks Overview" type="guide" />
+      <page path="/docs/hooks/reference/" title="Hooks Reference" type="reference" />
+      <page path="/docs/ide-integration/" title="IDE Integration" type="guide" />
+      <page path="/docs/tools/mcp-server/" title="MCP Servers" type="guide" />
+      <page path="/docs/cli/model-routing/" title="Model Routing" type="guide" />
+      <page path="/docs/cli/model/" title="Model Selection" type="guide" />
+      <page path="/docs/cli/model-steering/" title="Model Steering" type="guide" />
+      <page path="/docs/cli/notifications/" title="Notifications" type="guide" />
+      <page path="/docs/cli/plan-mode/" title="Plan Mode" type="guide" />
+      <page path="/docs/core/subagents/" title="Subagents" type="guide" />
+      <page path="/docs/core/remote-agents/" title="Remote Subagents" type="guide" />
+      <page path="/docs/cli/rewind/" title="Rewind" type="guide" />
+      <page path="/docs/cli/sandbox/" title="Sandboxing" type="guide" />
+      <page path="/docs/cli/settings/" title="Settings" type="reference" />
+      <page path="/docs/cli/telemetry/" title="Telemetry" type="reference" />
+      <page path="/docs/cli/token-caching/" title="Token Caching" type="guide" />
+    </section>
+
+    <!-- 5. Configuration -->
+    <section name="Configuration" path-prefix="/docs/cli" page-count="8">
+      <page path="/docs/cli/custom-commands/" title="Custom Commands" type="guide" />
+      <page path="/docs/cli/enterprise/" title="Enterprise Configuration" type="guide" />
+      <page path="/docs/cli/gemini-ignore/" title="Ignore Files (.geminiignore)" type="reference" />
+      <page path="/docs/cli/generation-settings/" title="Model Configuration" type="reference" />
+      <page path="/docs/cli/gemini-md/" title="Project Context (GEMINI.md)" type="guide" />
+      <page path="/docs/cli/system-prompt/" title="System Prompt Override" type="guide" />
+      <page path="/docs/cli/themes/" title="Themes" type="guide" />
+      <page path="/docs/cli/trusted-folders/" title="Trusted Folders" type="guide" />
+    </section>
+
+    <!-- 6. Reference -->
+    <section name="Reference" path-prefix="/docs/reference" page-count="6">
+      <page path="/docs/reference/commands/" title="Command Reference" type="reference" />
+      <page path="/docs/reference/configuration/" title="Configuration Reference" type="reference" />
+      <page path="/docs/reference/keyboard-shortcuts/" title="Keyboard Shortcuts" type="reference" />
+      <page path="/docs/reference/memport/" title="Memory Import Processor" type="tool-reference" />
+      <page path="/docs/reference/policy-engine/" title="Policy Engine" type="reference" />
+      <page path="/docs/reference/tools/" title="Tools Reference" type="tool-reference" />
+    </section>
+
+    <!-- 7. Resources -->
+    <section name="Resources" path-prefix="/docs/resources" page-count="5">
+      <page path="/docs/resources/faq/" title="FAQ" type="reference" />
+      <page path="/docs/resources/quota-and-pricing/" title="Quota and Pricing" type="reference" />
+      <page path="/docs/resources/tos-privacy/" title="Terms and Privacy" type="reference" />
+      <page path="/docs/resources/troubleshooting/" title="Troubleshooting" type="guide" />
+      <page path="/docs/resources/uninstall/" title="Uninstall" type="guide" />
+    </section>
+
+    <!-- 8. Development -->
+    <section name="Development" path-prefix="/docs" page-count="5">
+      <page path="/docs/contributing/" title="Contribution Guide" type="guide" />
+      <page path="/docs/integration-tests/" title="Integration Testing" type="guide" />
+      <page path="/docs/issue-and-pr-automation/" title="Issue and PR Automation" type="guide" />
+      <page path="/docs/local-development/" title="Local Development" type="guide" />
+      <page path="/docs/npm/" title="NPM Package Structure" type="reference" />
+    </section>
+
+    <!-- 9. Releases -->
+    <section name="Releases" path-prefix="/docs/changelogs" page-count="3">
+      <page path="/docs/changelogs/" title="Release Notes" type="changelog" />
+      <page path="/docs/changelogs/latest/" title="Stable Release" type="changelog" />
+      <page path="/docs/changelogs/preview/" title="Preview Release" type="changelog" />
+    </section>
+  </sections>
+
+  <navigation>
+    <default-section>Get Started</default-section>
+    <search-priority>
+      <section>Get Started</section>
+      <section>Tutorials</section>
+      <section>Features</section>
+      <section>Configuration</section>
+      <section>Reference</section>
+      <section>Extensions</section>
+    </search-priority>
+    <tips>
+      <tip>Start with /docs/get-started/ for installation and quickstart</tip>
+      <tip>Use /docs/cli/tutorials/ for step-by-step guides on common tasks</tip>
+      <tip>Configuration covers GEMINI.md, model settings, themes, and enterprise setup</tip>
+      <tip>For building plugins, see /docs/extensions/</tip>
+      <tip>Complete command and tool reference at /docs/reference/</tip>
+      <tip>Subagents and model routing are key features for advanced workflows</tip>
+    </tips>
+  </navigation>
+</agents>

--- a/public/gemini-cli/index.html
+++ b/public/gemini-cli/index.html
@@ -1,0 +1,476 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gemini CLI Documentation — AgentNav</title>
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      background: #0f0f1a;
+      color: #e0e0e0;
+      min-height: 100vh;
+      line-height: 1.6;
+    }
+
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 48px 24px 40px;
+    }
+
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: #6b7280;
+      text-decoration: none;
+      font-size: 0.85rem;
+      margin-bottom: 40px;
+      transition: color 0.2s;
+    }
+
+    .back-link:hover {
+      color: #4285f4;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 56px;
+    }
+
+    h1 {
+      font-size: 2.4rem;
+      font-weight: 800;
+      color: #ffffff;
+      margin-bottom: 10px;
+      letter-spacing: -0.03em;
+    }
+
+    h1 span {
+      background: linear-gradient(135deg, #4285f4, #34a853);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .subtitle {
+      font-size: 1rem;
+      color: #8892a8;
+    }
+
+    .subtitle a {
+      color: #4285f4;
+      text-decoration: none;
+    }
+
+    .subtitle a:hover {
+      text-decoration: underline;
+    }
+
+    .badge-row {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      margin-top: 20px;
+      flex-wrap: wrap;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 5px 12px;
+      background: rgba(66, 133, 244, 0.1);
+      border: 1px solid rgba(66, 133, 244, 0.2);
+      border-radius: 16px;
+      font-size: 0.8rem;
+      color: #8ab4f8;
+    }
+
+    .badge strong {
+      color: #a8bcfa;
+    }
+
+    .section-label {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 20px;
+    }
+
+    .formats-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+      margin-bottom: 56px;
+    }
+
+    .format-card {
+      background: #161625;
+      border: 1px solid #2a2a40;
+      border-radius: 14px;
+      padding: 24px;
+      text-decoration: none;
+      color: inherit;
+      transition: all 0.25s ease;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      position: relative;
+    }
+
+    .format-card:hover {
+      border-color: #4285f4;
+      transform: translateY(-2px);
+      box-shadow: 0 10px 28px rgba(66, 133, 244, 0.1);
+    }
+
+    .card-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .card-icon {
+      width: 44px;
+      height: 44px;
+      border-radius: 11px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.1rem;
+      font-weight: 800;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+
+    .card-icon.json { background: rgba(16, 185, 129, 0.15); color: #34d399; }
+    .card-icon.md   { background: rgba(99, 102, 241, 0.15); color: #818cf8; }
+    .card-icon.xml  { background: rgba(245, 158, 11, 0.15); color: #fbbf24; }
+    .card-icon.txt  { background: rgba(239, 68, 68, 0.15); color: #f87171; }
+
+    .rec-badge {
+      padding: 3px 8px;
+      background: rgba(16, 185, 129, 0.12);
+      border: 1px solid rgba(16, 185, 129, 0.25);
+      border-radius: 8px;
+      font-size: 0.68rem;
+      font-weight: 700;
+      color: #34d399;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .format-card h3 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #ffffff;
+    }
+
+    .format-card .desc {
+      font-size: 0.85rem;
+      color: #8892a8;
+      line-height: 1.45;
+    }
+
+    .meta-row {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .meta-item {
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+
+    .meta-item strong {
+      color: #9ca3af;
+    }
+
+    .card-link {
+      font-size: 0.78rem;
+      color: #4285f4;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .card-link .arrow {
+      transition: transform 0.2s;
+    }
+
+    .format-card:hover .card-link .arrow {
+      transform: translateX(4px);
+    }
+
+    .sections-block {
+      background: #161625;
+      border: 1px solid #2a2a40;
+      border-radius: 14px;
+      padding: 32px;
+      margin-bottom: 56px;
+    }
+
+    .sections-block h2 {
+      font-size: 1.15rem;
+      font-weight: 700;
+      color: #ffffff;
+      margin-bottom: 20px;
+    }
+
+    .sections-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .sections-table th {
+      text-align: left;
+      font-size: 0.72rem;
+      font-weight: 600;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 8px 0;
+      border-bottom: 1px solid #2a2a40;
+    }
+
+    .sections-table th:last-child {
+      text-align: right;
+    }
+
+    .sections-table td {
+      padding: 10px 0;
+      font-size: 0.88rem;
+      border-bottom: 1px solid rgba(42, 42, 64, 0.5);
+    }
+
+    .sections-table td:first-child {
+      color: #ffffff;
+      font-weight: 500;
+    }
+
+    .sections-table td:nth-child(2) {
+      color: #8892a8;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.8rem;
+    }
+
+    .sections-table td:last-child {
+      text-align: right;
+      color: #8ab4f8;
+      font-weight: 600;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.82rem;
+    }
+
+    .sections-table tr:last-child td {
+      border-bottom: none;
+      padding-top: 14px;
+      font-weight: 700;
+    }
+
+    .sections-table tr:last-child td:first-child {
+      color: #9ca3af;
+    }
+
+    .sections-table tr:last-child td:last-child {
+      color: #4285f4;
+      font-size: 0.9rem;
+    }
+
+    footer {
+      text-align: center;
+      padding: 24px;
+      border-top: 1px solid #1e1e30;
+      color: #4b5563;
+      font-size: 0.8rem;
+    }
+
+    footer a {
+      color: #4285f4;
+      text-decoration: none;
+    }
+
+    footer a:hover {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 600px) {
+      h1 { font-size: 1.8rem; }
+      .formats-grid { grid-template-columns: 1fr; }
+      .container { padding: 32px 16px; }
+      .meta-row { gap: 8px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a class="back-link" href="/">&larr; Back to all docs</a>
+
+    <header>
+      <h1>Gemini <span>CLI</span> Documentation</h1>
+      <p class="subtitle">
+        <a href="https://geminicli.com/docs" target="_blank" rel="noopener">geminicli.com/docs</a>
+        — 69 pages, 9 sections
+      </p>
+      <div class="badge-row">
+        <span class="badge"><strong>69</strong> pages</span>
+        <span class="badge"><strong>9</strong> sections</span>
+        <span class="badge"><strong>4</strong> formats</span>
+        <span class="badge"><strong>100%</strong> parse confidence</span>
+      </div>
+    </header>
+
+    <p class="section-label">Choose Format</p>
+    <div class="formats-grid">
+      <a class="format-card" href="agents.json">
+        <div class="card-top">
+          <div class="card-icon json">{}</div>
+          <span class="rec-badge">Recommended</span>
+        </div>
+        <h3>JSON</h3>
+        <p class="desc">Structured, machine-parseable. Best parse confidence.</p>
+        <div class="meta-row">
+          <span class="meta-item"><strong>~8.5 KB</strong> size</span>
+          <span class="meta-item"><strong>~2,400</strong> tokens</span>
+          <span class="meta-item"><strong>100%</strong> confidence</span>
+        </div>
+        <div class="card-link">
+          <span>agents.json</span>
+          <span class="arrow">&rarr;</span>
+        </div>
+      </a>
+
+      <a class="format-card" href="agents.md">
+        <div class="card-top">
+          <div class="card-icon md">#</div>
+          <span></span>
+        </div>
+        <h3>Markdown</h3>
+        <p class="desc">Natural language structure. Best for LLM consumption.</p>
+        <div class="meta-row">
+          <span class="meta-item"><strong>~6.4 KB</strong> size</span>
+          <span class="meta-item"><strong>~1,700</strong> tokens</span>
+          <span class="meta-item"><strong>100%</strong> confidence</span>
+        </div>
+        <div class="card-link">
+          <span>agents.md</span>
+          <span class="arrow">&rarr;</span>
+        </div>
+      </a>
+
+      <a class="format-card" href="agents.xml">
+        <div class="card-top">
+          <div class="card-icon xml">&lt;/&gt;</div>
+          <span></span>
+        </div>
+        <h3>XML</h3>
+        <p class="desc">DOM/XPath parseable. Structured with attributes.</p>
+        <div class="meta-row">
+          <span class="meta-item"><strong>~8.0 KB</strong> size</span>
+          <span class="meta-item"><strong>~1,800</strong> tokens</span>
+          <span class="meta-item"><strong>100%</strong> confidence</span>
+        </div>
+        <div class="card-link">
+          <span>agents.xml</span>
+          <span class="arrow">&rarr;</span>
+        </div>
+      </a>
+
+      <a class="format-card" href="agents.txt">
+        <div class="card-top">
+          <div class="card-icon txt">TXT</div>
+          <span></span>
+        </div>
+        <h3>Plain Text</h3>
+        <p class="desc">Most token-efficient. ~600 tokens for 69 pages.</p>
+        <div class="meta-row">
+          <span class="meta-item"><strong>~4.2 KB</strong> size</span>
+          <span class="meta-item"><strong>~600</strong> tokens</span>
+          <span class="meta-item"><strong>100%</strong> confidence</span>
+        </div>
+        <div class="card-link">
+          <span>agents.txt</span>
+          <span class="arrow">&rarr;</span>
+        </div>
+      </a>
+    </div>
+
+    <div class="sections-block">
+      <h2>Documentation Sections</h2>
+      <table class="sections-table">
+        <thead>
+          <tr>
+            <th>Section</th>
+            <th>Path</th>
+            <th>Pages</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Get Started</td>
+            <td>/docs/</td>
+            <td>7</td>
+          </tr>
+          <tr>
+            <td>Tutorials</td>
+            <td>/docs/cli/tutorials/</td>
+            <td>10</td>
+          </tr>
+          <tr>
+            <td>Extensions</td>
+            <td>/docs/extensions/</td>
+            <td>5</td>
+          </tr>
+          <tr>
+            <td>Features</td>
+            <td>/docs/</td>
+            <td>20</td>
+          </tr>
+          <tr>
+            <td>Configuration</td>
+            <td>/docs/cli/</td>
+            <td>8</td>
+          </tr>
+          <tr>
+            <td>Reference</td>
+            <td>/docs/reference/</td>
+            <td>6</td>
+          </tr>
+          <tr>
+            <td>Resources</td>
+            <td>/docs/resources/</td>
+            <td>5</td>
+          </tr>
+          <tr>
+            <td>Development</td>
+            <td>/docs/</td>
+            <td>5</td>
+          </tr>
+          <tr>
+            <td>Releases</td>
+            <td>/docs/changelogs/</td>
+            <td>3</td>
+          </tr>
+          <tr>
+            <td>Total</td>
+            <td></td>
+            <td>69</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <footer>
+      agents.txt v0.2 | AgentNav |
+      <a href="/">All Documentation Sets</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -59,7 +59,7 @@
 
     .docs-grid {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: repeat(3, 1fr);
       gap: 20px;
       margin-bottom: 80px;
     }
@@ -245,10 +245,23 @@
           <span class="card-arrow">&rarr;</span>
         </div>
       </a>
+
+      <a class="doc-card" href="/gemini-cli/">
+        <div class="card-header">
+          <div class="card-icon" style="background: linear-gradient(135deg, rgba(66, 133, 244, 0.2), rgba(52, 168, 83, 0.2)); color: #4285f4;">G</div>
+          <span class="format-badge" style="background: rgba(66, 133, 244, 0.1); border-color: rgba(66, 133, 244, 0.2); color: #8ab4f8;">4 formats</span>
+        </div>
+        <h3>Gemini CLI</h3>
+        <p>Google Gemini CLI documentation, 69 pages across 9 sections</p>
+        <div class="card-header">
+          <span style="font-size: 0.78rem; color: #6b7280; font-family: 'SF Mono', 'Fira Code', monospace;">/gemini-cli/</span>
+          <span class="card-arrow">&rarr;</span>
+        </div>
+      </a>
     </div>
 
     <footer>
-      agents.txt v0.1 | AgentNav PoC
+      agents.txt v0.2 | AgentNav
     </footer>
   </div>
 </body>


### PR DESCRIPTION
## Summary

- **Issue #22 — Gemini CLI cross-contamination**: Navigation Guide sections in the gemini-cli doc set contained GPT Codex content instead of Gemini CLI content. Fixed across `agents.md`, `agents.txt`, `agents.xml`, and `agents.json`.
- **Issue #21/#22 — Claude Code mislabeling**: The "Claude Code" label was inaccurate — the doc set actually contains Anthropic Claude API Platform content sourced from `platform.claude.com`. Renamed to "Anthropic Claude API Documentation" across all 4 formats and root catalogs.
- Root catalog files (`/agents.json`, `/agents.md`, `/agents.txt`) updated to reflect corrected labels and new Gemini CLI entries.
- `last_updated` dates set to 2026-03-22 across all affected formats.

## Test plan

- [ ] Verify `public/gemini-cli/agents.md` Navigation Guide sections contain Gemini CLI content (not GPT Codex)
- [ ] Verify `public/claude-code/agents.*` title shows "Anthropic Claude API Documentation"
- [ ] Verify root `public/agents.json` lists all three doc sets with correct labels
- [ ] Confirm `public/index.html` landing page reflects updated doc set names
- [ ] Check that unrelated files (CLAUDE.md, nginx.conf, guides/) are NOT included in this PR

Closes #21
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)