### PR TITLE
Fix well-known discovery indexing paths

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -25,9 +25,16 @@ server {
         return 301 /$arg_docs/;
     }
 
-    # Backward compatibility: /.well-known/agents.* → /claude-code/agents.*
+    # Serve root well-known discovery paths without an external redirect so they
+    # stay indexable and avoid https→http downgrade issues behind a proxy/CDN.
     location ~ ^/\.well-known/agents\.(json|md|xml|txt)$ {
-        return 301 /claude-code/agents.$1;
+        rewrite ^/\.well-known/agents\.(json|md|xml|txt)$ /agents.$1 break;
+    }
+
+    # Provider-scoped well-known discovery paths:
+    # /gpt-codex/.well-known/agents.json → /gpt-codex/agents.json
+    location ~ ^/([^/]+)/\.well-known/agents\.(json|md|xml|txt)$ {
+        rewrite ^/([^/]+)/\.well-known/agents\.(json|md|xml|txt)$ /$1/agents.$2 break;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- serve root `/.well-known/agents.*` URLs with internal rewrites instead of external 301 redirects
- add provider-scoped `/{provider}/.well-known/agents.*` rewrites so documented discovery URLs return 200

## Verification
- docker build succeeds locally
- local nginx smoke confirmed 200 for:
  - `/.well-known/agents.txt`
  - `/.well-known/agents.json`
  - `/gpt-codex/.well-known/agents.json`
  - `/gpt-codex/.well-known/agents.txt`

## Why
This addresses Search Console exclusions observed on March 28, 2026 for the AgentNav domain:
- `/.well-known/agents.txt` reported as a redirect page
- `/gpt-codex/.well-known/agents.json` reported as 404
